### PR TITLE
remove unused imports to avoid collision with `Predicate` names

### DIFF
--- a/Sources/Loco/Filetype/Filetype.swift
+++ b/Sources/Loco/Filetype/Filetype.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Funswift
 
 struct FileType: OptionSet {

--- a/Sources/Loco/Filters/Pathfilter.swift
+++ b/Sources/Loco/Filters/Pathfilter.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Funswift
 
 public enum PathFilter {


### PR DESCRIPTION
Both `Foundation` and `Funswift` frameworks has `Predicate` structure, so we have to use framework name as a namespace or just remove unused imports.

<img width="534" alt="image" src="https://github.com/konrad1977/loco/assets/1907011/c9d93105-3d07-4237-a096-2eddeba3f437">
